### PR TITLE
Upgrades knex to v0.19.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/fiferdc/knex-mysql2-deadlock#readme",
   "devDependencies": {
     "ava": "^0.25.0",
-    "knex": "^0.12.6",
+    "knex": "^0.19.5",
     "mysql2": "^1.5.3",
     "proxyquire": "^2.0.1",
     "sinon": "6.0.0"


### PR DESCRIPTION
Addresses vulnerability: `https://nvd.nist.gov/vuln/detail/CVE-2019-10757`